### PR TITLE
fix: update lockfile version to 3 for npm compatibility

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -2,6 +2,9 @@ import fs from 'fs-extra';
 import { getCccscConfigPath, getCccscLockPath, ensureCccscConfigDir } from './paths.js';
 import { parseRepositoryPath } from './github.js';
 
+// Current lockfile version for npm compatibility
+const CURRENT_LOCKFILE_VERSION = 3;
+
 export async function loadCccscConfig(isLocal = false) {
   const configPath = getCccscConfigPath(isLocal);
   
@@ -36,7 +39,7 @@ export async function loadCccscLock(isLocal = false) {
   }
   
   return {
-    lockfileVersion: 1,
+    lockfileVersion: CURRENT_LOCKFILE_VERSION,
     repositories: {}
   };
 }

--- a/tests/utils/config.test.js
+++ b/tests/utils/config.test.js
@@ -114,7 +114,7 @@ describe('Config Utils', () => {
       const result = await loadCccscLock(true);
 
       expect(result).toEqual({
-        lockfileVersion: 1,
+        lockfileVersion: 3,
         repositories: {}
       });
     });


### PR DESCRIPTION
## Summary
- Fix lockfile version issue where `npx cccsc@latest add` was creating lockfiles with version 1
- Update default lockfile version to 3 for current npm compatibility
- Replace magic number with `CURRENT_LOCKFILE_VERSION` constant

## Test plan
- [ ] Run `npx cccsc@latest add` and verify lockfile version is 3
- [ ] Verify existing functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)