### PR TITLE
fix: change lockfile only field from string array to object array

### DIFF
--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -85,7 +85,11 @@ export async function installCommand(options) {
         
         // Update lock file with actually installed commands
         if (lock.repositories[repoKey]) {
-          lock.repositories[repoKey].only = installedCommandNames;
+          lock.repositories[repoKey].only = installedCommandNames.map(name => ({
+            name: name,
+            path: `${name}.md`,
+            alias: null
+          }));
         } else {
           // This should not happen normally, but let's be safe
           logWarning(`Lock file entry for ${repoKey} not found, skipping lock update`);

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -48,7 +48,9 @@ async function removeCommandFromLock(commandName, repoKey, lock) {
   
   const repoLock = lock.repositories[repoKey];
   if (repoLock.only && repoLock.only.length > 0) {
-    const commandIndex = repoLock.only.indexOf(commandName);
+    const commandIndex = repoLock.only.findIndex(item => 
+      typeof item === 'string' ? item === commandName : item.name === commandName
+    );
     if (commandIndex !== -1) {
       repoLock.only.splice(commandIndex, 1);
       

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -119,8 +119,15 @@ export async function addRepositoryToLock(user, repo, revision, commandPath = nu
   // Add new command to "only" list if specified
   if (commandPath) {
     const commandName = commandPath.split('/').pop().replace('.md', '');
-    if (!repoEntry.only.includes(commandName)) {
-      repoEntry.only.push(commandName);
+    const commandExists = repoEntry.only.some(item => 
+      typeof item === 'string' ? item === commandName : item.name === commandName
+    );
+    if (!commandExists) {
+      repoEntry.only.push({
+        name: commandName,
+        path: commandPath,
+        alias: null
+      });
     }
   } else if (!existingRepo || !existingRepo.only || existingRepo.only.length === 0) {
     // If no specific command and no existing "only" list, keep empty (all commands)


### PR DESCRIPTION
## Summary
- Updated lockfile structure to match cccsc.json format 
- Changed "only" field from string array to object array with name, path, and alias properties
- Modified config.js, install.js, and remove.js to handle the new object format

## Test plan
- [ ] Test installing commands and verify lockfile format
- [ ] Test removing commands and verify lockfile updates correctly
- [ ] Test with existing lockfiles to ensure backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)