### PR TITLE
feat: exclude documentation files from command installation

### DIFF
--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -1,6 +1,28 @@
 import axios from 'axios';
 import { logWarning } from './errors.js';
 
+// Default documentation files to exclude from command installation
+const DEFAULT_EXCLUDED_FILES = [
+  'readme',
+  'claude'
+];
+
+/**
+ * Check if a markdown file should be excluded from command installation
+ * @param {string} fileName - File name without extension
+ * @returns {boolean} True if file should be excluded
+ */
+export function shouldExcludeFile(fileName) {
+  // Handle invalid inputs
+  if (typeof fileName !== 'string' || !fileName) {
+    return false;
+  }
+  
+  // Simple case-insensitive check
+  const normalizedName = fileName.toLowerCase();
+  return DEFAULT_EXCLUDED_FILES.includes(normalizedName);
+}
+
 export function parseRepositoryPath(repoPath) {
   const parts = repoPath.split('/');
   
@@ -74,10 +96,17 @@ export async function findMarkdownFiles(user, repo, basePath = '', branch = 'mai
     
     for (const item of contents) {
       if (item.type === 'file' && item.name.endsWith('.md')) {
+        const fileName = item.name.replace('.md', '');
+        
+        // Skip documentation files
+        if (shouldExcludeFile(fileName)) {
+          continue;
+        }
+        
         const relativePath = basePath ? `${basePath}/${item.name}` : item.name;
         files.push({
           path: relativePath,
-          name: item.name.replace('.md', ''),
+          name: fileName,
           fullPath: item.path
         });
       } else if (item.type === 'dir') {

--- a/tests/utils/github-simple.test.js
+++ b/tests/utils/github-simple.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { parseRepositoryPath } from '../../src/utils/github.js';
+import { parseRepositoryPath, shouldExcludeFile } from '../../src/utils/github.js';
 
 describe('GitHub Utils - Simple Tests', () => {
   describe('parseRepositoryPath', () => {
@@ -33,6 +33,25 @@ describe('GitHub Utils - Simple Tests', () => {
     test('should throw error for invalid format', () => {
       expect(() => parseRepositoryPath('invalid')).toThrow('Invalid repository path format. Expected user/repo or user/repo/command');
       expect(() => parseRepositoryPath('')).toThrow('Invalid repository path format. Expected user/repo or user/repo/command');
+    });
+  });
+
+  describe('shouldExcludeFile', () => {
+    test('should exclude README and CLAUDE files', () => {
+      expect(shouldExcludeFile('README')).toBe(true);
+      expect(shouldExcludeFile('readme')).toBe(true);
+      expect(shouldExcludeFile('CLAUDE')).toBe(true);
+      expect(shouldExcludeFile('claude')).toBe(true);
+    });
+
+    test('should not exclude command files', () => {
+      expect(shouldExcludeFile('NOT_TO_INCLUDE_FILE')).toBe(false);
+    });
+
+    test('should handle invalid input', () => {
+      expect(shouldExcludeFile('')).toBe(false);
+      expect(shouldExcludeFile(null)).toBe(false);
+      expect(shouldExcludeFile(undefined)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
This PR adds functionality to automatically exclude documentation files (README.md and CLAUDE.md) from being installed as slash commands when using `cccsc add user/repo`.

## Background

First of all, thank you for creating such a wonderful CLI tool. I use it daily and find it extremely helpful. I've been using it to manage my custom slash commands at https://github.com/syou6162/claude-code-commands.

### The Problem

When installing slash commands with:
```bash
npx cccsc add --global syou6162/claude-code-commands
```

The installation succeeds, but README.md and CLAUDE.md files appear in the slash command autocomplete suggestions:

```
│ > /                                                                │
╰────────────────────────────────────────────────────────────────────╯
  /cccsc:syou6162:claude-code-commands:CLAUDE         CLAUDE.md (user)
  /cccsc:syou6162:claude-code-commands:estimate_pr_size    Pull Requestのサイズ見積もりと分割提案 (user)
  /cccsc:syou6162:claude-code-commands:README         claude-code-commands (user)
```

These documentation files are not meant to be slash commands and clutter the autocomplete list.

## Changes

- Add `shouldExcludeFile` utility function to identify documentation files
- Integrate exclusion logic into `findMarkdownFiles` to filter out README and CLAUDE files
- Add comprehensive test coverage for the exclusion functionality
- Support case-insensitive matching only (no hyphen/underscore normalization)

## Implementation Details

The exclusion is applied by default without requiring any configuration. The implementation:
- Performs simple case-insensitive comparison for README and CLAUDE files
- Excludes only README and CLAUDE files, allowing other documentation like CHANGELOG to be used as commands if needed
- Maintains backward compatibility for existing installations

## Breaking Change Consideration

This is a breaking change that alters the default behavior. I considered:
1. Maintaining existing behavior with opt-in exclusion
2. Adding configuration flags to control exclusion

However, given the purpose of this tool (managing Claude Code slash commands), excluding documentation files by default seems more appropriate. Documentation files are rarely, if ever, intended as executable commands.

If you prefer a non-breaking approach with configuration options, I'm happy to revise the implementation accordingly.

## Testing

Added unit tests to verify:
- README and CLAUDE files are excluded in various naming conventions
- Command files are not affected
- Invalid input handling works correctly

This change improves the user experience by preventing accidental installation of documentation files as commands.